### PR TITLE
update urllib3 dependency and remove disable SubjectAltNameWarning

### DIFF
--- a/piawg.py
+++ b/piawg.py
@@ -5,10 +5,6 @@ import urllib3
 import subprocess
 import urllib.parse
 
-# PIA uses the CN attribute for certificates they issue themselves.
-# This will be deprecated by urllib3 at some point in the future, and generates a warning (that we ignore).
-urllib3.disable_warnings(urllib3.exceptions.SubjectAltNameWarning)
-
 
 class piawg:
     def __init__(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ icmplib==3.0.3
 idna==3.3
 pick==1.0.0
 PyYAML==6.0.1
-requests==2.26.0
-requests-toolbelt==0.9.1
+requests==2.32.4
+requests-toolbelt==1.0.0
 routeros==0.1.1
-urllib3==1.26.6
+urllib3==2.5.0
 wgconfig==1.0.1


### PR DESCRIPTION
`urllib3` and `requests` are fairly out of date. This PR update those dependencies and removes the warning for `urllib3.exceptions.SubjectAltNameWarning` that's no longer relevant (it longer exists in the list of [Exceptions and Warnings](https://urllib3.readthedocs.io/en/latest/reference/urllib3.exceptions.html)).