### PR TITLE
disable x509 strict when validating ca.rsa.4096.crt

### DIFF
--- a/piawg.py
+++ b/piawg.py
@@ -6,27 +6,29 @@ import subprocess
 import urllib.parse
 import ssl
 import warnings
+from sys import version_info
 
 
 # fix for Python 3.13 enforcing X509 strict verification, based on
 # https://stackoverflow.com/questions/79358216/python-v3-13-has-broken-email-delivery-due-to-an-ssl-change
-try:
-    original_urllib3_request_context = requests.adapters._urllib3_request_context
+if version_info[0] == 3 and version_info[1] >= 13:
+    print("Attempting X509_STRICT workaround for ca.rsa.4096.crt")
+    try:
+        original_urllib3_request_context = requests.adapters._urllib3_request_context
 
-    def patched_urllib3_request_context(*args, **kwargs):
-        host_params, pool_kwargs = original_urllib3_request_context(*args, **kwargs)
-        if 'ca_certs' in pool_kwargs and pool_kwargs['ca_certs'] == 'ca.rsa.4096.crt':
-            warnings.warn("Disabling VERIFY_X509_STRICT and VERIFY_X509_PARTIAL_CHAIN")
-            context = urllib3.util.create_urllib3_context()
-            context.verify_flags = context.verify_flags & ~ssl.VERIFY_X509_STRICT
-            # context.verify_flags = context.verify_flags & ~ssl.VERIFY_X509_PARTIAL_CHAIN
-            pool_kwargs["ssl_context"] = context
+        def patched_urllib3_request_context(*args, **kwargs):
+            host_params, pool_kwargs = original_urllib3_request_context(*args, **kwargs)
+            if 'ca_certs' in pool_kwargs and pool_kwargs['ca_certs'] == 'ca.rsa.4096.crt':
+                warnings.warn("Disabling VERIFY_X509_STRICT and VERIFY_X509_PARTIAL_CHAIN")
+                context = urllib3.util.create_urllib3_context()
+                context.verify_flags = context.verify_flags & ~ssl.VERIFY_X509_STRICT
+                pool_kwargs["ssl_context"] = context
 
-        return host_params, pool_kwargs
+            return host_params, pool_kwargs
 
-    requests.adapters._urllib3_request_context = patched_urllib3_request_context
-except:
-    pass
+        requests.adapters._urllib3_request_context = patched_urllib3_request_context
+    except:
+        pass
 
 
 

--- a/piawg.py
+++ b/piawg.py
@@ -4,6 +4,30 @@ from requests_toolbelt.adapters import host_header_ssl
 import urllib3
 import subprocess
 import urllib.parse
+import ssl
+import warnings
+
+
+# fix for Python 3.13 enforcing X509 strict verification, based on
+# https://stackoverflow.com/questions/79358216/python-v3-13-has-broken-email-delivery-due-to-an-ssl-change
+try:
+    original_urllib3_request_context = requests.adapters._urllib3_request_context
+
+    def patched_urllib3_request_context(*args, **kwargs):
+        host_params, pool_kwargs = original_urllib3_request_context(*args, **kwargs)
+        if 'ca_certs' in pool_kwargs and pool_kwargs['ca_certs'] == 'ca.rsa.4096.crt':
+            warnings.warn("Disabling VERIFY_X509_STRICT and VERIFY_X509_PARTIAL_CHAIN")
+            context = urllib3.util.create_urllib3_context()
+            context.verify_flags = context.verify_flags & ~ssl.VERIFY_X509_STRICT
+            # context.verify_flags = context.verify_flags & ~ssl.VERIFY_X509_PARTIAL_CHAIN
+            pool_kwargs["ssl_context"] = context
+
+        return host_params, pool_kwargs
+
+    requests.adapters._urllib3_request_context = patched_urllib3_request_context
+except:
+    pass
+
 
 # PIA uses the CN attribute for certificates they issue themselves.
 # This will be deprecated by urllib3 at some point in the future, and generates a warning (that we ignore).


### PR DESCRIPTION
Python 3.13 `ssl` now enforces strict X509 verification. Unfortunately PIA have not included the `critical` basic constraint:

```shell
$ openssl x509 -text -noout -in ca.rsa.4096.crt | grep Constraints
            X509v3 Basic Constraints: 
$ 
```
 
which means running `generate-config.py` errors out when the cert fails verification with:
 
```
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Basic Constraints of CA cert not marked critical (_ssl.c:1032)

During handling of the above exception, another exception occurred:

urllib3.exceptions.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Basic Constraints of CA cert not marked critical (_ssl.c:1032)

The above exception was the direct cause of the following exception:

urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='173.244.62.2', port=443): Max retries exceeded with url: /authv3/generateToken (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Basic Constraints of CA cert not marked critical (_ssl.c:1032)')))

During handling of the above exception, another exception occurred:

requests.exceptions.SSLError: HTTPSConnectionPool(host='173.244.62.2', port=443): Max retries exceeded with url: /authv3/generateToken (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Basic Constraints of CA cert not marked critical (_ssl.c:1032)')))
```
 
This PR turns off the strict verification for the request that uses the `ca.rsa.4096.crt` certificate and restores functionality with Python >= 3.13.

See also:
- https://docs.python.org/3/whatsnew/3.13.html
- https://security.stackexchange.com/questions/30974/which-properties-of-a-x-509-certificate-should-be-critical-and-which-not
- https://stackoverflow.com/questions/79358216/python-v3-13-has-broken-email-delivery-due-to-an-ssl-change