### PR TITLE
update pick dependency

### DIFF
--- a/generate-config.py
+++ b/generate-config.py
@@ -18,7 +18,7 @@ def main():
 
     # Parse arguments
     parser = argparse.ArgumentParser(description='Generate PIA wireguard config')
-    parser.add_argument('-r', '--region', dest='region', choices=["auto"]+regions, help='Allowed values are '+', '.join(regions), metavar='')
+    parser.add_argument('-r', '--region', dest='region', choices=["auto"]+regions, help='Allowed values are '+', '.join(["auto"]+regions), metavar='')
     parser.add_argument('--sort-latency', action='store_true', help='Display lowest latency regions first (requires root)')
     parser.add_argument('-f', '--config', help='Name of the generated config file')
     args = parser.parse_args()
@@ -48,7 +48,9 @@ def main():
             if region == "auto":
                 region = closest_regions[0]
             else:
-                region, index = pick(closest_regions, title, options_map_func=lambda x: "{} ({} ms)".format(x,region_latencies[x]))
+                closest_regions_with_latency=["{} ({} ms)".format(x,region_latencies[x]) for x in closest_regions]
+                _, index = pick(closest_regions_with_latency, title)
+                region = closest_regions[index]
         else:
             region, index = pick(regions, title)
     print("Selected '{}'".format(region))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ certifi==2022.6.15
 charset-normalizer==2.0.12
 icmplib==3.0.3
 idna==3.3
-pick==1.0.0
+pick==2.4.0
 PyYAML==6.0.1
 requests==2.32.4
 requests-toolbelt==1.0.0


### PR DESCRIPTION
This PR updates the dependency on [pick](https://pypi.org/project/pick/) and also displays 'auto' as a valid region in the help text:

```$ python generate-config.py --help
usage: generate-config.py [-h] [-r ] [--sort-latency] [-f CONFIG]

Generate PIA wireguard config

options:
  -h, --help           show this help message and exit
  -r, --region         Allowed values are auto, AU Adelaide, AU Brisbane, AU
```